### PR TITLE
Mark a few mods as client only so they don't download on my server

### DIFF
--- a/v1/index.toml
+++ b/v1/index.toml
@@ -26,7 +26,7 @@ metafile = true
 
 [[files]]
 file = "mods/better-ping-display.pw.toml"
-hash = "ee1d0200a7a320407045c0a6fbf76731b4df2bc482e4614294b35d2c09e17ac9"
+hash = "472c2d8d721592760042e56a7a5e5eb1c2fefa4e80236b7c44af2b62250f93a7"
 metafile = true
 
 [[files]]
@@ -36,7 +36,7 @@ metafile = true
 
 [[files]]
 file = "mods/clean-logs.pw.toml"
-hash = "8c12678b6fe1365369ce857a479f63efcb5139f31dfb53c643fe77f32344cd9f"
+hash = "722b14c4ecd0019df4bea4718d42efdf99bb43a6f5fb72ff717d96be1530f9c5"
 metafile = true
 
 [[files]]
@@ -106,7 +106,7 @@ metafile = true
 
 [[files]]
 file = "mods/lazydfu.pw.toml"
-hash = "dff60d2308d754d1260ecac0572b6eadc476f1e5a86b1a0a061bc758b5869f4a"
+hash = "06e282b71429e7bc90d0ca68544f381f75eec620477747243ef4b1d7f316160e"
 metafile = true
 
 [[files]]
@@ -136,7 +136,7 @@ metafile = true
 
 [[files]]
 file = "mods/shulkerboxtooltip.pw.toml"
-hash = "c13417e54c19f172a875fcd27f7ef4f0417a033d415c7adc602016ed60d51520"
+hash = "8644926055ec0e395a840b2a0bf3a07926bf35847fe80d163928a0b2dd068b23"
 metafile = true
 
 [[files]]

--- a/v1/mods/better-ping-display.pw.toml
+++ b/v1/mods/better-ping-display.pw.toml
@@ -1,6 +1,6 @@
 name = "Better Ping Display"
 filename = "BetterPingDisplay-Fabric-1.19.2-1.1.1.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/v1/mods/clean-logs.pw.toml
+++ b/v1/mods/clean-logs.pw.toml
@@ -1,6 +1,6 @@
 name = "Clean Logs"
 filename = "clean-logs-1.2.0.jar"
-side = "both"
+side = "client"
 
 [download]
 url = "https://cdn.modrinth.com/data/OTteoJUk/versions/1.2.0/clean-logs-1.2.0.jar"

--- a/v1/mods/lazydfu.pw.toml
+++ b/v1/mods/lazydfu.pw.toml
@@ -1,6 +1,6 @@
 name = "LazyDFU"
 filename = "lazydfu-0.1.3.jar"
-side = "both"
+side = "client"
 
 [download]
 url = "https://cdn.modrinth.com/data/hvFnDODi/versions/0.1.3/lazydfu-0.1.3.jar"

--- a/v1/mods/shulkerboxtooltip.pw.toml
+++ b/v1/mods/shulkerboxtooltip.pw.toml
@@ -1,6 +1,6 @@
 name = "ShulkerBoxTooltip"
 filename = "shulkerboxtooltip-fabric-3.2.2+1.19.2.jar"
-side = "both"
+side = "client"
 
 [download]
 url = "https://cdn.modrinth.com/data/2M01OLQq/versions/luwoDnlv/shulkerboxtooltip-fabric-3.2.2%2B1.19.2.jar"

--- a/v1/pack.toml
+++ b/v1/pack.toml
@@ -7,7 +7,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "f3df789bbdb05a2ef11cb8c9448afa49248444f86fa6bde7cbd57f0445a1da2a"
+hash = "fb9eb4b12359454de250adc64d4614563ff68d870c928fae4d498d0bbe974dc4"
 
 [versions]
 minecraft = "1.19.2"


### PR DESCRIPTION
I haven't been using this script when my server starts but I fancy changing that! These 4 have no effect that I can see when installed on the server so I reckon it's fine to mark them as client only mods (they haven't been running on the server thus far)