### PR TITLE
Update mods to latest versions

### DIFF
--- a/v1/index.toml
+++ b/v1/index.toml
@@ -11,12 +11,12 @@ metafile = true
 
 [[files]]
 file = "mods/architectury-api.pw.toml"
-hash = "498275573c2e70eed181d4ff78c849ba6ad735cd20b6228d52ddd29949d8fb48"
+hash = "ff8eca97a093cf7056dbc273e5d898fd7a91c3ea0c4022dcd1c93484b6a98d42"
 metafile = true
 
 [[files]]
 file = "mods/badpackets.pw.toml"
-hash = "0615da5afa35bf67d460f5dd8283db2825e702e10c0ffad2a5d3654fa214bd48"
+hash = "4a6efd2c5b409b8b5b521f413029daa0b525e0c23bace9b965f0c0dc3a54a60d"
 metafile = true
 
 [[files]]
@@ -71,12 +71,12 @@ metafile = true
 
 [[files]]
 file = "mods/farmers-delight.pw.toml"
-hash = "8fd31cdd59706ecec8914938ff3f1efbf27898c45b7e5a27c95b7f2795fd6d82"
+hash = "44f55c60287c6d60a4421d13d9fcb541dcf2c9abb52d277fbb9e7d2f1fb69002"
 metafile = true
 
 [[files]]
 file = "mods/ferrite-core.pw.toml"
-hash = "875a2e98ab24ea6f5127a703c6cd38ec0462b6d8729d8bc10a5d9ed9b4bfb644"
+hash = "6b70d0d4f3eb96c47f9c8c6ee38a7ec7469094f444784c9addeb9367d7d43f35"
 metafile = true
 
 [[files]]
@@ -91,7 +91,7 @@ metafile = true
 
 [[files]]
 file = "mods/horsebuff.pw.toml"
-hash = "3166f05f5ac8a0c0f470b1741e4fa89c58f798111ca5eb11f55cfac2db5c19e1"
+hash = "a1f6e5c7010b82cc022a4ae37290966eff652658a0d0f6598d6519f068b659ae"
 metafile = true
 
 [[files]]
@@ -111,27 +111,27 @@ metafile = true
 
 [[files]]
 file = "mods/lithium.pw.toml"
-hash = "4d3878e51889ea7cd10b3a2c5e1e099e72e69823589dd48a1d70480f4a13ef63"
+hash = "f36a7d197088fc7100948d4671325d9703343b174c29190e7267fd0a97808977"
 metafile = true
 
 [[files]]
 file = "mods/modmenu.pw.toml"
-hash = "d29903087b36894a48e42ad17ac285a4cd8dbffdc077efed32ac17356b654d7b"
+hash = "d825518ca6d479d4e05e8b95ee9090889274390fcdb312190d8ec7d18bf95825"
 metafile = true
 
 [[files]]
 file = "mods/oh-the-biomes-youll-go.pw.toml"
-hash = "5f39d2f928741c29afd70814c853475ded4edaf55231c8a7d9bc265af3eab160"
+hash = "3456696f1958f3bef97e40e73873f518bc89fbc7bdf75668b849f86de7eb20a3"
 metafile = true
 
 [[files]]
 file = "mods/qsl.pw.toml"
-hash = "2c9c88a4ce530a735f94dc8afdd6d4c3c0f52fb682bbbbff28ace7e159db4db6"
+hash = "2d88e65376af1ec36348b880a0f2c953567eb907c1a4cced684d3b57c62a0e85"
 metafile = true
 
 [[files]]
 file = "mods/roughly-enough-items.pw.toml"
-hash = "7e07a7480a6913da43f078d25ccce421bab1298844294476a6a56dc17ca3c9a1"
+hash = "cae0bab95e778ae4c4fe572c93103164b5f9996f4112788d2a70a7abcbdd5741"
 metafile = true
 
 [[files]]
@@ -151,27 +151,27 @@ metafile = true
 
 [[files]]
 file = "mods/terrablender.pw.toml"
-hash = "889db0e1c6cf5ca95d8303549e85fefcdfa9397c2ebbfa101a7e2298d0c8a208"
+hash = "78443226eb317d736dc16a990dc3ddb9fd043416ef1db88931ad80d90b938f8a"
 metafile = true
 
 [[files]]
 file = "mods/wthit.pw.toml"
-hash = "318e09ae8caa3eb8de86d2aa6b8f34f41a6b7ec55b89dfd58deb2c6f972fbd63"
+hash = "5697479c8f6470684f977569618f5a1232e42a2473dc4436c6293a6f9ce3c434"
 metafile = true
 
 [[files]]
 file = "mods/xaeros-minimap.pw.toml"
-hash = "1ce62edf8798c52e71486eeb3f847402700eba2a4097c95609fcbd50217a6e78"
+hash = "f9ef1b02ae3ca6d8557affa405824be8c047332e688d1956b3c79e6995c2ffa0"
 metafile = true
 
 [[files]]
 file = "mods/xaeros-world-map.pw.toml"
-hash = "6f7b05a48b676094e7af2726e9183855868287943735b18633a9020856e3385f"
+hash = "38b9a9b4b1c443fb1000d7f1747428568a7c62a25339450e9e288971a41be5a1"
 metafile = true
 
 [[files]]
 file = "mods/yacl.pw.toml"
-hash = "d3265c5b5ea151720cf381a07f98de0e5a8845cab1306078211e9a3b13577ade"
+hash = "fd9e50d178ceb1f8b736a801e24fe386247205e6f21a326f4a02e25179a1a01a"
 metafile = true
 
 [[files]]

--- a/v1/mods/architectury-api.pw.toml
+++ b/v1/mods/architectury-api.pw.toml
@@ -1,20 +1,17 @@
 name = "Architectury API"
-filename = "architectury-6.3.49-fabric.jar"
+filename = "architectury-6.4.62-fabric.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/lhGA9TYQ/versions/KE5bu0Vd/architectury-6.3.49-fabric.jar"
+url = "https://cdn.modrinth.com/data/lhGA9TYQ/versions/JD6EmQHI/architectury-6.4.62-fabric.jar"
 hash-format = "sha1"
-hash = "9c6173d2c38306fd8f87d33e259d33fecb5e1dea"
+hash = "cccddd4f8221a6fc373f786de42e3fc57992b166"
 
 [update]
 [update.modrinth]
 mod-id = "lhGA9TYQ"
-version = "KE5bu0Vd"
+version = "JD6EmQHI"
 
 [option]
 optional = true
-default = false
-description = """(Required by Roughly Enough Items)
-
-A library that helps some mods support both Quilt/Fabric and Forge mod loaders."""
+description = "(Required by Roughly Enough Items)\n\nA library that helps some mods support both Quilt/Fabric and Forge mod loaders."

--- a/v1/mods/architectury-api.pw.toml
+++ b/v1/mods/architectury-api.pw.toml
@@ -14,4 +14,6 @@ version = "JD6EmQHI"
 
 [option]
 optional = true
-description = "(Required by Roughly Enough Items)\n\nA library that helps some mods support both Quilt/Fabric and Forge mod loaders."
+description = """(Required by Roughly Enough Items)
+
+A library that helps some mods support both Quilt/Fabric and Forge mod loaders."""

--- a/v1/mods/badpackets.pw.toml
+++ b/v1/mods/badpackets.pw.toml
@@ -14,5 +14,7 @@ version = "AifWRdyF"
 
 [option]
 optional = true
-description = "(Required by WTHIT)\n\nA library to allow mods using it to work on both Quilt/Fabric and Forge servers even if you're using the other mod loader."
+description = """(Required by WTHIT)
+
+A library to allow mods using it to work on both Quilt/Fabric and Forge servers even if you're using the other mod loader."""
 default = true

--- a/v1/mods/badpackets.pw.toml
+++ b/v1/mods/badpackets.pw.toml
@@ -1,20 +1,18 @@
 name = "bad packets"
-filename = "badpackets-fabric-0.2.0.jar"
+filename = "badpackets-fabric-0.2.1.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/ftdbN0KK/versions/fabric-0.2.0/badpackets-fabric-0.2.0.jar"
+url = "https://cdn.modrinth.com/data/ftdbN0KK/versions/AifWRdyF/badpackets-fabric-0.2.1.jar"
 hash-format = "sha1"
-hash = "8d0855fd49c43921108431501600d976b1927559"
+hash = "17438ba70d88752f73d814405927450c81d035b9"
 
 [update]
 [update.modrinth]
 mod-id = "ftdbN0KK"
-version = "Sbpp5LIv"
+version = "AifWRdyF"
 
 [option]
 optional = true
+description = "(Required by WTHIT)\n\nA library to allow mods using it to work on both Quilt/Fabric and Forge servers even if you're using the other mod loader."
 default = true
-description = """(Required by WTHIT)
-
-A library to allow mods using it to work on both Quilt/Fabric and Forge servers even if you're using the other mod loader."""

--- a/v1/mods/farmers-delight.pw.toml
+++ b/v1/mods/farmers-delight.pw.toml
@@ -1,20 +1,18 @@
 name = "Farmer's Delight"
-filename = "farmers-delight-fabric-1.19.X-1.3.5.jar"
+filename = "farmers-delight-fabric-1.19.X-1.3.9.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/4EakbH8e/versions/j28o9UzD/farmers-delight-fabric-1.19.X-1.3.5.jar"
+url = "https://cdn.modrinth.com/data/4EakbH8e/versions/baQ9tohQ/farmers-delight-fabric-1.19.X-1.3.9.jar"
 hash-format = "sha1"
-hash = "9db05900480cc9f163f76bc80031b22037a93791"
+hash = "5ee4d71ca173a6c2164a252ae092f2b9d9afd4cf"
 
 [update]
 [update.modrinth]
 mod-id = "4EakbH8e"
-version = "j28o9UzD"
+version = "baQ9tohQ"
 
 [option]
 optional = false
+description = "(Required because it adds new items, blocks and food effects)\n\nExpands upon farming and cooking. For more info, see https://github.com/vectorwing/FarmersDelight/wiki/Getting-Started or consult the advancements, recipe book or REI."
 default = true
-description = """(Required because it adds new items, blocks and food effects)
-
-Expands upon farming and cooking. For more info, see https://github.com/vectorwing/FarmersDelight/wiki/Getting-Started or consult the advancements, recipe book or REI."""

--- a/v1/mods/farmers-delight.pw.toml
+++ b/v1/mods/farmers-delight.pw.toml
@@ -14,5 +14,7 @@ version = "baQ9tohQ"
 
 [option]
 optional = false
-description = "(Required because it adds new items, blocks and food effects)\n\nExpands upon farming and cooking. For more info, see https://github.com/vectorwing/FarmersDelight/wiki/Getting-Started or consult the advancements, recipe book or REI."
+description = """(Required because it adds new items, blocks and food effects)
+
+Expands upon farming and cooking. For more info, see https://github.com/vectorwing/FarmersDelight/wiki/Getting-Started or consult the advancements, recipe book or REI."""
 default = true

--- a/v1/mods/ferrite-core.pw.toml
+++ b/v1/mods/ferrite-core.pw.toml
@@ -14,5 +14,7 @@ version = "kwjHqfz7"
 
 [option]
 optional = true
-description = "(*Strongly* recommended!)\n\nMemory usage optimisation mod."
+description = """(*Strongly* recommended!)
+
+Memory usage optimisation mod."""
 default = true

--- a/v1/mods/ferrite-core.pw.toml
+++ b/v1/mods/ferrite-core.pw.toml
@@ -1,20 +1,18 @@
 name = "FerriteCore"
-filename = "ferritecore-5.0.0-fabric.jar"
+filename = "ferritecore-5.0.3-fabric.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/uXXizFIs/versions/5.0.0-fabric/ferritecore-5.0.0-fabric.jar"
+url = "https://cdn.modrinth.com/data/uXXizFIs/versions/kwjHqfz7/ferritecore-5.0.3-fabric.jar"
 hash-format = "sha1"
-hash = "14ab2f560fce8f20f5af07129dd71130ab9bb03f"
+hash = "4a124f8205e39b84a156db2d1e435c5708328d7b"
 
 [update]
 [update.modrinth]
 mod-id = "uXXizFIs"
-version = "7epbwkFg"
+version = "kwjHqfz7"
 
 [option]
 optional = true
+description = "(*Strongly* recommended!)\n\nMemory usage optimisation mod."
 default = true
-description = """(*Strongly* recommended!)
-
-Memory usage optimisation mod."""

--- a/v1/mods/horsebuff.pw.toml
+++ b/v1/mods/horsebuff.pw.toml
@@ -1,23 +1,13 @@
 name = "Horse Buff"
-filename = "HorseBuff-1.19-pre2-2.0.0.jar"
+filename = "HorseBuff-1.19-2.0.1.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/IrrG0G8l/versions/2.0.0-1.19/HorseBuff-1.19-pre2-2.0.0.jar"
+url = "https://cdn.modrinth.com/data/IrrG0G8l/versions/1.19-2.0.1/HorseBuff-1.19-2.0.1.jar"
 hash-format = "sha1"
-hash = "70a9a08f5da46c0700adf9bec2d1615611a2311f"
+hash = "acd8be74c59291dbf09e2c08de11cabb4bfcd6dd"
 
 [update]
 [update.modrinth]
 mod-id = "IrrG0G8l"
-version = "bJJgTASh"
-
-[option]
-optional = true
-default = true
-description = """Bugfixes and quality-of-life tweaks around horses.
-
-The most important fixes only needed us to install it on the server, but there are some additional client-side benefits:
-* Make the horse translucent when you look down while riding
-* Adjust the horse's head's angle downward while riding
-* Open the inventory while sprinting to show your inventory and not the horse's"""
+version = "DvXgcRxr"

--- a/v1/mods/horsebuff.pw.toml
+++ b/v1/mods/horsebuff.pw.toml
@@ -11,3 +11,13 @@ hash = "acd8be74c59291dbf09e2c08de11cabb4bfcd6dd"
 [update.modrinth]
 mod-id = "IrrG0G8l"
 version = "DvXgcRxr"
+
+[option]
+optional = true
+default = true
+description = """Bugfixes and quality-of-life tweaks around horses.
+
+The most important fixes only needed us to install it on the server, but there are some additional client-side benefits:
+* Make the horse translucent when you look down while riding
+* Adjust the horse's head's angle downward while riding
+* Open the inventory while sprinting to show your inventory and not the horse's"""

--- a/v1/mods/lithium.pw.toml
+++ b/v1/mods/lithium.pw.toml
@@ -14,5 +14,7 @@ version = "7scJ9RTg"
 
 [option]
 optional = true
-description = "(*Strongly* recommended!)\n\nGame logic optimisation mod."
+description = """(*Strongly* recommended!)
+
+Game logic optimisation mod."""
 default = true

--- a/v1/mods/lithium.pw.toml
+++ b/v1/mods/lithium.pw.toml
@@ -1,20 +1,18 @@
 name = "Lithium"
-filename = "lithium-fabric-mc1.19.2-0.10.1.jar"
+filename = "lithium-fabric-mc1.19.2-0.10.4.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/gvQqBUqZ/versions/xVm1caOt/lithium-fabric-mc1.19.2-0.10.1.jar"
+url = "https://cdn.modrinth.com/data/gvQqBUqZ/versions/7scJ9RTg/lithium-fabric-mc1.19.2-0.10.4.jar"
 hash-format = "sha1"
-hash = "6c0749e47025bfe6237c39b0b1ff7f596c5796c1"
+hash = "8ff81f60681521e96b403fc3dd095f5c64b15745"
 
 [update]
 [update.modrinth]
 mod-id = "gvQqBUqZ"
-version = "xVm1caOt"
+version = "7scJ9RTg"
 
 [option]
 optional = true
+description = "(*Strongly* recommended!)\n\nGame logic optimisation mod."
 default = true
-description = """(*Strongly* recommended!)
-
-Game logic optimisation mod."""

--- a/v1/mods/modmenu.pw.toml
+++ b/v1/mods/modmenu.pw.toml
@@ -1,20 +1,18 @@
 name = "Mod Menu"
-filename = "modmenu-4.1.0.jar"
+filename = "modmenu-4.1.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/mOgUt4GM/versions/NAs8eiQa/modmenu-4.1.0.jar"
+url = "https://cdn.modrinth.com/data/mOgUt4GM/versions/V4hnfgRO/modmenu-4.1.2.jar"
 hash-format = "sha1"
-hash = "1aad3aa7819d708938d014248fe5ebd850648910"
+hash = "495674289dcba88b6df3d86b7590c7b192b993fe"
 
 [update]
 [update.modrinth]
 mod-id = "mOgUt4GM"
-version = "NAs8eiQa"
+version = "V4hnfgRO"
 
 [option]
 optional = false
+description = "(Not strictly required, but configuring mods will otherwise be harder)\n\nA menu for listing installed mods and accessing their config screens."
 default = true
-description = """(Not strictly required, but configuring mods will otherwise be harder)
-
-A menu for listing installed mods and accessing their config screens."""

--- a/v1/mods/modmenu.pw.toml
+++ b/v1/mods/modmenu.pw.toml
@@ -14,5 +14,7 @@ version = "V4hnfgRO"
 
 [option]
 optional = false
-description = "(Not strictly required, but configuring mods will otherwise be harder)\n\nA menu for listing installed mods and accessing their config screens."
+description = """(Not strictly required, but configuring mods will otherwise be harder)
+
+A menu for listing installed mods and accessing their config screens."""
 default = true

--- a/v1/mods/oh-the-biomes-youll-go.pw.toml
+++ b/v1/mods/oh-the-biomes-youll-go.pw.toml
@@ -14,5 +14,7 @@ version = "oFcbieSw"
 
 [option]
 optional = false
-description = "(Required since it adds new blocks and items)\n\nAdds many new biomes and some structures, some of which are made with new blocks."
+description = """(Required since it adds new blocks and items)
+
+Adds many new biomes and some structures, some of which are made with new blocks."""
 default = true

--- a/v1/mods/oh-the-biomes-youll-go.pw.toml
+++ b/v1/mods/oh-the-biomes-youll-go.pw.toml
@@ -3,18 +3,16 @@ filename = "Oh_The_Biomes_You'll_Go-fabric-1.19.2-2.0.0.13.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/uE1WpIAk/versions/B3LkZn0y/Oh_The_Biomes_You%27ll_Go-fabric-1.19.2-2.0.0.13.jar"
+url = "https://cdn.modrinth.com/data/uE1WpIAk/versions/oFcbieSw/Oh_The_Biomes_You%27ll_Go-fabric-1.19.2-2.0.0.13.jar"
 hash-format = "sha1"
-hash = "77148303bbb275a6cd3d5397e420e84a72db5c5e"
+hash = "306b3605a45e0ad643e41dc3993d106d9dd7b9bf"
 
 [update]
 [update.modrinth]
 mod-id = "uE1WpIAk"
-version = "B3LkZn0y"
+version = "oFcbieSw"
 
 [option]
 optional = false
+description = "(Required since it adds new blocks and items)\n\nAdds many new biomes and some structures, some of which are made with new blocks."
 default = true
-description = """(Required since it adds new blocks and items)
-
-Adds many new biomes and some structures, some of which are made with new blocks."""

--- a/v1/mods/qsl.pw.toml
+++ b/v1/mods/qsl.pw.toml
@@ -14,5 +14,7 @@ version = "hmX9pHvE"
 
 [option]
 optional = false
-description = "(Required by pretty much every mod in the pack)\n\nQuilt's API and its Fabric compatibility layer"
+description = """(Required by pretty much every mod in the pack)
+
+Quilt's API and its Fabric compatibility layer"""
 default = true

--- a/v1/mods/qsl.pw.toml
+++ b/v1/mods/qsl.pw.toml
@@ -1,20 +1,18 @@
 name = "Quilted Fabric API (QFAPI) / Quilt Standard Libraries (QSL)"
-filename = "quilted-fabric-api-4.0.0-beta.19+0.64.0-1.19.2.jar"
+filename = "qfapi-4.0.0-beta.24_qsl-3.0.0-beta.24_fapi-0.68.0_mc-1.19.2.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/qvIfYCYJ/versions/zzHaJbi0/quilted-fabric-api-4.0.0-beta.19%2B0.64.0-1.19.2.jar"
+url = "https://cdn.modrinth.com/data/qvIfYCYJ/versions/hmX9pHvE/qfapi-4.0.0-beta.24_qsl-3.0.0-beta.24_fapi-0.68.0_mc-1.19.2.jar"
 hash-format = "sha1"
-hash = "dc88c7b41357c19274d24f1e27a164aa1ff237a0"
+hash = "257bf70e080614f73e745dee12c63cef5f8687de"
 
 [update]
 [update.modrinth]
 mod-id = "qvIfYCYJ"
-version = "zzHaJbi0"
+version = "hmX9pHvE"
 
 [option]
 optional = false
+description = "(Required by pretty much every mod in the pack)\n\nQuilt's API and its Fabric compatibility layer"
 default = true
-description = """(Required by pretty much every mod in the pack)
-
-Quilt's API and its Fabric compatibility layer"""

--- a/v1/mods/roughly-enough-items.pw.toml
+++ b/v1/mods/roughly-enough-items.pw.toml
@@ -1,22 +1,17 @@
 name = "Roughly Enough Items (REI)"
-filename = "RoughlyEnoughItems-9.1.565.jar"
+filename = "RoughlyEnoughItems-9.1.580.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/nfn13YXA/versions/COjCjJ9Q/RoughlyEnoughItems-9.1.565.jar"
+url = "https://cdn.modrinth.com/data/nfn13YXA/versions/AzBJJs8X/RoughlyEnoughItems-9.1.580.jar"
 hash-format = "sha1"
-hash = "fd4c2a1c51115f09ff2632d24eb66c06d8f987c3"
+hash = "5af2e66ec5c2be474107c3e9f9972054982f608c"
 
 [update]
 [update.modrinth]
 mod-id = "nfn13YXA"
-version = "COjCjJ9Q"
+version = "AzBJJs8X"
 
 [option]
 optional = true
-default = false
-description = """(Recommended, especially if you haven't played the game in ages)
-
-An item and recipe browser that should save you from having to look up the wiki so much. Also includes items and recipes added by other mods.
-
-(Requires Architectury API and Cloth Config API to be enabled as well)"""
+description = "(Recommended, especially if you haven't played the game in ages)\n\nAn item and recipe browser that should save you from having to look up the wiki so much. Also includes items and recipes added by other mods.\n\n(Requires Architectury API and Cloth Config API to be enabled as well)"

--- a/v1/mods/roughly-enough-items.pw.toml
+++ b/v1/mods/roughly-enough-items.pw.toml
@@ -14,4 +14,8 @@ version = "AzBJJs8X"
 
 [option]
 optional = true
-description = "(Recommended, especially if you haven't played the game in ages)\n\nAn item and recipe browser that should save you from having to look up the wiki so much. Also includes items and recipes added by other mods.\n\n(Requires Architectury API and Cloth Config API to be enabled as well)"
+description = """(Recommended, especially if you haven't played the game in ages)
+
+An item and recipe browser that should save you from having to look up the wiki so much. Also includes items and recipes added by other mods.
+
+(Requires Architectury API and Cloth Config API to be enabled as well)"""

--- a/v1/mods/terrablender.pw.toml
+++ b/v1/mods/terrablender.pw.toml
@@ -1,18 +1,18 @@
 name = "TerraBlender (Fabric)"
-filename = "TerraBlender-fabric-1.19.2-2.0.1.129.jar"
+filename = "TerraBlender-fabric-1.19.2-2.0.1.136.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "9f69628f801f5a661c5039b565a492bd6781b83d"
+hash = "5ca6cc1eb69df42650c6d5d478f58e1241109771"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4057291
+file-id = 4205731
 project-id = 565956
 
 [option]
 optional = false
-default = true
 description = "Required by Oh The Biomes You'll Go"
+default = true

--- a/v1/mods/wthit.pw.toml
+++ b/v1/mods/wthit.pw.toml
@@ -14,5 +14,9 @@ version = "zHptoLXM"
 
 [option]
 optional = true
-description = "(Recommended, especially if you haven't played with the required mods before or haven't played Minecraft in ages)\n\n\"What the Hell is That?\" Adds a configurable tooltip that tells you what the block, entity etc. you're looking at is called, plus some additional info (e.g. entity health, pet owner, what mod it's from).\n\n(Requires bad packets to be enabled as well)"
+description = """(Recommended, especially if you haven't played with the required mods before or haven't played Minecraft in ages)
+
+\"What the Hell is That?\" Adds a configurable tooltip that tells you what the block, entity etc. you're looking at is called, plus some additional info (e.g. entity health, pet owner, what mod it's from).
+
+(Requires bad packets to be enabled as well)"""
 default = true

--- a/v1/mods/wthit.pw.toml
+++ b/v1/mods/wthit.pw.toml
@@ -1,22 +1,18 @@
 name = "WTHIT"
-filename = "wthit-quilt-5.13.3.jar"
+filename = "wthit-quilt-5.13.4.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/6AQIaxuO/versions/NW38iTn5/wthit-quilt-5.13.3.jar"
+url = "https://cdn.modrinth.com/data/6AQIaxuO/versions/zHptoLXM/wthit-quilt-5.13.4.jar"
 hash-format = "sha1"
-hash = "0a628b273c8c1151b2429e064967e3bc8523cac0"
+hash = "9c31a7aad960aac1d21b4ae084921cd8704d9b52"
 
 [update]
 [update.modrinth]
 mod-id = "6AQIaxuO"
-version = "NW38iTn5"
+version = "zHptoLXM"
 
 [option]
 optional = true
+description = "(Recommended, especially if you haven't played with the required mods before or haven't played Minecraft in ages)\n\n\"What the Hell is That?\" Adds a configurable tooltip that tells you what the block, entity etc. you're looking at is called, plus some additional info (e.g. entity health, pet owner, what mod it's from).\n\n(Requires bad packets to be enabled as well)"
 default = true
-description = """(Recommended, especially if you haven't played with the required mods before or haven't played Minecraft in ages)
-
-\"What the Hell is That?\" Adds a configurable tooltip that tells you what the block, entity etc. you're looking at is called, plus some additional info (e.g. entity health, pet owner, what mod it's from).
-
-(Requires bad packets to be enabled as well)"""

--- a/v1/mods/xaeros-minimap.pw.toml
+++ b/v1/mods/xaeros-minimap.pw.toml
@@ -1,22 +1,18 @@
 name = "Xaero's Minimap"
-filename = "Xaeros_Minimap_22.16.0_Fabric_1.19.1.jar"
+filename = "Xaeros_Minimap_22.17.0_Fabric_1.19.1.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "df3782ce71f696df6a9daf8d7a85158d29a2755f"
+hash = "e613c45e1373dbddcb1640451237916c34c3abeb"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4026491
+file-id = 4181107
 project-id = 263420
 
 [option]
 optional = false
+description = "(Required since installing it on the server prevents it from being client optional)\n\nA highly configurable minimap.\n\n(Per the author's conditions for distribution in modpacks, here's a link back to their site: https://chocolateminecraft.com/minimap2.php)"
 default = true
-description = """(Required since installing it on the server prevents it from being client optional)
-
-A highly configurable minimap.
-
-(Per the author's conditions for distribution in modpacks, here's a link back to their site: https://chocolateminecraft.com/minimap2.php)"""

--- a/v1/mods/xaeros-minimap.pw.toml
+++ b/v1/mods/xaeros-minimap.pw.toml
@@ -14,5 +14,9 @@ project-id = 263420
 
 [option]
 optional = false
-description = "(Required since installing it on the server prevents it from being client optional)\n\nA highly configurable minimap.\n\n(Per the author's conditions for distribution in modpacks, here's a link back to their site: https://chocolateminecraft.com/minimap2.php)"
+description = """(Required since installing it on the server prevents it from being client optional)
+
+A highly configurable minimap.
+
+(Per the author's conditions for distribution in modpacks, here's a link back to their site: https://chocolateminecraft.com/minimap2.php)"""
 default = true

--- a/v1/mods/xaeros-world-map.pw.toml
+++ b/v1/mods/xaeros-world-map.pw.toml
@@ -1,22 +1,18 @@
 name = "Xaero's World Map"
-filename = "XaerosWorldMap_1.28.1_Fabric_1.19.1.jar"
+filename = "XaerosWorldMap_1.28.7_Fabric_1.19.1.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "45b3e788850cd0c2ae2c5a87e943b41b2f696e4a"
+hash = "efde86a2093103f150d317c5861720734cc56a7d"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4026544
+file-id = 4193008
 project-id = 317780
 
 [option]
 optional = false
+description = "(Required since installing it on the server prevents it from being client optional)\n\nA highly configurable world map.\n\n(Per the author's conditions for distribution in modpacks, here's a link back to their site: https://chocolateminecraft.com/worldmap.php)"
 default = true
-description = """(Required since installing it on the server prevents it from being client optional)
-
-A highly configurable world map.
-
-(Per the author's conditions for distribution in modpacks, here's a link back to their site: https://chocolateminecraft.com/worldmap.php)"""

--- a/v1/mods/xaeros-world-map.pw.toml
+++ b/v1/mods/xaeros-world-map.pw.toml
@@ -14,5 +14,9 @@ project-id = 317780
 
 [option]
 optional = false
-description = "(Required since installing it on the server prevents it from being client optional)\n\nA highly configurable world map.\n\n(Per the author's conditions for distribution in modpacks, here's a link back to their site: https://chocolateminecraft.com/worldmap.php)"
+description = """(Required since installing it on the server prevents it from being client optional)
+
+A highly configurable world map.
+
+(Per the author's conditions for distribution in modpacks, here's a link back to their site: https://chocolateminecraft.com/worldmap.php)"""
 default = true

--- a/v1/mods/yacl.pw.toml
+++ b/v1/mods/yacl.pw.toml
@@ -14,5 +14,7 @@ version = "mW3CVg5N"
 
 [option]
 optional = true
-description = "(Required by Cull Less Leaves)\n\nYet another config screen library used by some mods."
+description = """(Required by Cull Less Leaves)
+
+Yet another config screen library used by some mods."""
 default = true

--- a/v1/mods/yacl.pw.toml
+++ b/v1/mods/yacl.pw.toml
@@ -1,20 +1,18 @@
 name = "YetAnotherConfigLib"
-filename = "YetAnotherConfigLib-1.6.0.jar"
+filename = "YetAnotherConfigLib-1.7.1.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/1eAoo2KR/versions/EyhlJvkj/YetAnotherConfigLib-1.6.0.jar"
+url = "https://cdn.modrinth.com/data/1eAoo2KR/versions/mW3CVg5N/YetAnotherConfigLib-1.7.1.jar"
 hash-format = "sha1"
-hash = "82296f5c091f6339f6539c54bde02343789c518a"
+hash = "9694c6e52e946820f9945e2b9ee8a463c1e426fd"
 
 [update]
 [update.modrinth]
 mod-id = "1eAoo2KR"
-version = "EyhlJvkj"
+version = "mW3CVg5N"
 
 [option]
 optional = true
+description = "(Required by Cull Less Leaves)\n\nYet another config screen library used by some mods."
 default = true
-description = """(Required by Cull Less Leaves)
-
-Yet another config screen library used by some mods."""

--- a/v1/pack.toml
+++ b/v1/pack.toml
@@ -7,7 +7,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "f3df789bbdb05a2ef11cb8c9448afa49248444f86fa6bde7cbd57f0445a1da2a"
+hash = "93b19e37940841d9ed0768975eb33adda9d07bfee801eb30458e34e240be26d3"
 
 [versions]
 minecraft = "1.19.2"


### PR DESCRIPTION
I ran 'packwiz update --all' and here is the result with one exception: it's having a lot of trouble parsing the newest version for Horsebuff so I had to manually set the right version code there. Seems this is a known issue and it's more on mod creators not using machine understandable versioning schemes consistently :(

Didn't verify that all the other mods are up to date but might spot check a few later on

I'm not sure why it decided to replace linebreaks in mod descriptions with \n for me (I've set this up through WSL and am running commands that way). Second commit fixes that, might be a bit of trying to fight the tool though. It also rearranged the files somewhat, gonna leave that as is