### PR TITLE
Update mods to latest versions

### DIFF
--- a/v1/index.toml
+++ b/v1/index.toml
@@ -11,12 +11,12 @@ metafile = true
 
 [[files]]
 file = "mods/architectury-api.pw.toml"
-hash = "498275573c2e70eed181d4ff78c849ba6ad735cd20b6228d52ddd29949d8fb48"
+hash = "197b03f0517e116c9c6c1d08efc1c8e4386e971dece0f1340227bfe443eaa409"
 metafile = true
 
 [[files]]
 file = "mods/badpackets.pw.toml"
-hash = "0615da5afa35bf67d460f5dd8283db2825e702e10c0ffad2a5d3654fa214bd48"
+hash = "205dfe8fca3babd9008d8b23b7eff25fa4e86af8965f0f70fcbd58c486eb1b23"
 metafile = true
 
 [[files]]
@@ -71,12 +71,12 @@ metafile = true
 
 [[files]]
 file = "mods/farmers-delight.pw.toml"
-hash = "8fd31cdd59706ecec8914938ff3f1efbf27898c45b7e5a27c95b7f2795fd6d82"
+hash = "6ac0dcedb1bedd066ec26b0984398687eb863e3aba59bef941767560f936acfc"
 metafile = true
 
 [[files]]
 file = "mods/ferrite-core.pw.toml"
-hash = "875a2e98ab24ea6f5127a703c6cd38ec0462b6d8729d8bc10a5d9ed9b4bfb644"
+hash = "0cae188182b162113ff3ef100c21463846f884646b3ce221921f4c4cd4116835"
 metafile = true
 
 [[files]]
@@ -91,7 +91,7 @@ metafile = true
 
 [[files]]
 file = "mods/horsebuff.pw.toml"
-hash = "3166f05f5ac8a0c0f470b1741e4fa89c58f798111ca5eb11f55cfac2db5c19e1"
+hash = "2ac4f4318902ea4f1b55cc079a38aba270645813540d943fbc59a2be01fdd7a2"
 metafile = true
 
 [[files]]
@@ -111,12 +111,12 @@ metafile = true
 
 [[files]]
 file = "mods/lithium.pw.toml"
-hash = "4d3878e51889ea7cd10b3a2c5e1e099e72e69823589dd48a1d70480f4a13ef63"
+hash = "fedb8c1cd7c5f9d0bd28a4b4ec665dbbc961ec94f1b9b8dab7deaba3d63a142a"
 metafile = true
 
 [[files]]
 file = "mods/modmenu.pw.toml"
-hash = "d29903087b36894a48e42ad17ac285a4cd8dbffdc077efed32ac17356b654d7b"
+hash = "a18682c39a0d2da6ab80651ead1866a3ddeb331605a48da81f091023439ec1e6"
 metafile = true
 
 [[files]]
@@ -126,12 +126,12 @@ metafile = true
 
 [[files]]
 file = "mods/qsl.pw.toml"
-hash = "2c9c88a4ce530a735f94dc8afdd6d4c3c0f52fb682bbbbff28ace7e159db4db6"
+hash = "d0e66dcb986de3a73a6109c508d54a1ad845bfdb8a681cf696c224f72a09d479"
 metafile = true
 
 [[files]]
 file = "mods/roughly-enough-items.pw.toml"
-hash = "7e07a7480a6913da43f078d25ccce421bab1298844294476a6a56dc17ca3c9a1"
+hash = "d860a218217198bb9f208a3c6ed1dca761be1411136c1c0b500ff3a75fcad2f6"
 metafile = true
 
 [[files]]
@@ -151,27 +151,27 @@ metafile = true
 
 [[files]]
 file = "mods/terrablender.pw.toml"
-hash = "889db0e1c6cf5ca95d8303549e85fefcdfa9397c2ebbfa101a7e2298d0c8a208"
+hash = "4fb1e98a657d0273bf7ca9fec264246b6999e4109b503a21aea3fb76f0f001cd"
 metafile = true
 
 [[files]]
 file = "mods/wthit.pw.toml"
-hash = "318e09ae8caa3eb8de86d2aa6b8f34f41a6b7ec55b89dfd58deb2c6f972fbd63"
+hash = "5ff38d3b3e9f001b665458f1562be582025b96b9ba46b4f19bf3c89b88888704"
 metafile = true
 
 [[files]]
 file = "mods/xaeros-minimap.pw.toml"
-hash = "1ce62edf8798c52e71486eeb3f847402700eba2a4097c95609fcbd50217a6e78"
+hash = "6b965ec07e82c78d5bffad9fc892702e1fd04fbf498bbad7e54599f9205a99be"
 metafile = true
 
 [[files]]
 file = "mods/xaeros-world-map.pw.toml"
-hash = "6f7b05a48b676094e7af2726e9183855868287943735b18633a9020856e3385f"
+hash = "ba7db23cdc69c4b0fe5f30ee7e14122a7d9a8bc1ce136e0f42ac9621e96cf745"
 metafile = true
 
 [[files]]
 file = "mods/yacl.pw.toml"
-hash = "d3265c5b5ea151720cf381a07f98de0e5a8845cab1306078211e9a3b13577ade"
+hash = "7f678fa440ed1426c98faedf31375501dd4fd385a68aa048532913cd2b166439"
 metafile = true
 
 [[files]]

--- a/v1/mods/architectury-api.pw.toml
+++ b/v1/mods/architectury-api.pw.toml
@@ -1,16 +1,16 @@
 name = "Architectury API"
-filename = "architectury-6.3.49-fabric.jar"
+filename = "architectury-6.4.62-fabric.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/lhGA9TYQ/versions/KE5bu0Vd/architectury-6.3.49-fabric.jar"
+url = "https://cdn.modrinth.com/data/lhGA9TYQ/versions/JD6EmQHI/architectury-6.4.62-fabric.jar"
 hash-format = "sha1"
-hash = "9c6173d2c38306fd8f87d33e259d33fecb5e1dea"
+hash = "cccddd4f8221a6fc373f786de42e3fc57992b166"
 
 [update]
 [update.modrinth]
 mod-id = "lhGA9TYQ"
-version = "KE5bu0Vd"
+version = "JD6EmQHI"
 
 [option]
 optional = true

--- a/v1/mods/badpackets.pw.toml
+++ b/v1/mods/badpackets.pw.toml
@@ -1,16 +1,16 @@
 name = "bad packets"
-filename = "badpackets-fabric-0.2.0.jar"
+filename = "badpackets-fabric-0.2.1.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/ftdbN0KK/versions/fabric-0.2.0/badpackets-fabric-0.2.0.jar"
+url = "https://cdn.modrinth.com/data/ftdbN0KK/versions/AifWRdyF/badpackets-fabric-0.2.1.jar"
 hash-format = "sha1"
-hash = "8d0855fd49c43921108431501600d976b1927559"
+hash = "17438ba70d88752f73d814405927450c81d035b9"
 
 [update]
 [update.modrinth]
 mod-id = "ftdbN0KK"
-version = "Sbpp5LIv"
+version = "AifWRdyF"
 
 [option]
 optional = true

--- a/v1/mods/farmers-delight.pw.toml
+++ b/v1/mods/farmers-delight.pw.toml
@@ -1,16 +1,16 @@
 name = "Farmer's Delight"
-filename = "farmers-delight-fabric-1.19.X-1.3.5.jar"
+filename = "farmers-delight-fabric-1.19.X-1.3.9.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/4EakbH8e/versions/j28o9UzD/farmers-delight-fabric-1.19.X-1.3.5.jar"
+url = "https://cdn.modrinth.com/data/4EakbH8e/versions/baQ9tohQ/farmers-delight-fabric-1.19.X-1.3.9.jar"
 hash-format = "sha1"
-hash = "9db05900480cc9f163f76bc80031b22037a93791"
+hash = "5ee4d71ca173a6c2164a252ae092f2b9d9afd4cf"
 
 [update]
 [update.modrinth]
 mod-id = "4EakbH8e"
-version = "j28o9UzD"
+version = "baQ9tohQ"
 
 [option]
 optional = false

--- a/v1/mods/ferrite-core.pw.toml
+++ b/v1/mods/ferrite-core.pw.toml
@@ -1,16 +1,16 @@
 name = "FerriteCore"
-filename = "ferritecore-5.0.0-fabric.jar"
+filename = "ferritecore-5.0.3-fabric.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/uXXizFIs/versions/5.0.0-fabric/ferritecore-5.0.0-fabric.jar"
+url = "https://cdn.modrinth.com/data/uXXizFIs/versions/kwjHqfz7/ferritecore-5.0.3-fabric.jar"
 hash-format = "sha1"
-hash = "14ab2f560fce8f20f5af07129dd71130ab9bb03f"
+hash = "4a124f8205e39b84a156db2d1e435c5708328d7b"
 
 [update]
 [update.modrinth]
 mod-id = "uXXizFIs"
-version = "7epbwkFg"
+version = "kwjHqfz7"
 
 [option]
 optional = true

--- a/v1/mods/horsebuff.pw.toml
+++ b/v1/mods/horsebuff.pw.toml
@@ -1,16 +1,16 @@
 name = "Horse Buff"
-filename = "HorseBuff-1.19-pre2-2.0.0.jar"
+filename = "HorseBuff-1.19-2.0.1.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/IrrG0G8l/versions/2.0.0-1.19/HorseBuff-1.19-pre2-2.0.0.jar"
+url = "https://cdn.modrinth.com/data/IrrG0G8l/versions/1.19-2.0.1/HorseBuff-1.19-2.0.1.jar"
 hash-format = "sha1"
-hash = "70a9a08f5da46c0700adf9bec2d1615611a2311f"
+hash = "acd8be74c59291dbf09e2c08de11cabb4bfcd6dd"
 
 [update]
 [update.modrinth]
 mod-id = "IrrG0G8l"
-version = "bJJgTASh"
+version = "DvXgcRxr"
 
 [option]
 optional = true

--- a/v1/mods/lithium.pw.toml
+++ b/v1/mods/lithium.pw.toml
@@ -1,16 +1,16 @@
 name = "Lithium"
-filename = "lithium-fabric-mc1.19.2-0.10.1.jar"
+filename = "lithium-fabric-mc1.19.2-0.10.4.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/gvQqBUqZ/versions/xVm1caOt/lithium-fabric-mc1.19.2-0.10.1.jar"
+url = "https://cdn.modrinth.com/data/gvQqBUqZ/versions/7scJ9RTg/lithium-fabric-mc1.19.2-0.10.4.jar"
 hash-format = "sha1"
-hash = "6c0749e47025bfe6237c39b0b1ff7f596c5796c1"
+hash = "8ff81f60681521e96b403fc3dd095f5c64b15745"
 
 [update]
 [update.modrinth]
 mod-id = "gvQqBUqZ"
-version = "xVm1caOt"
+version = "7scJ9RTg"
 
 [option]
 optional = true

--- a/v1/mods/modmenu.pw.toml
+++ b/v1/mods/modmenu.pw.toml
@@ -1,16 +1,16 @@
 name = "Mod Menu"
-filename = "modmenu-4.1.0.jar"
+filename = "modmenu-4.1.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/mOgUt4GM/versions/NAs8eiQa/modmenu-4.1.0.jar"
+url = "https://cdn.modrinth.com/data/mOgUt4GM/versions/V4hnfgRO/modmenu-4.1.2.jar"
 hash-format = "sha1"
-hash = "1aad3aa7819d708938d014248fe5ebd850648910"
+hash = "495674289dcba88b6df3d86b7590c7b192b993fe"
 
 [update]
 [update.modrinth]
 mod-id = "mOgUt4GM"
-version = "NAs8eiQa"
+version = "V4hnfgRO"
 
 [option]
 optional = false

--- a/v1/mods/qsl.pw.toml
+++ b/v1/mods/qsl.pw.toml
@@ -1,16 +1,16 @@
 name = "Quilted Fabric API (QFAPI) / Quilt Standard Libraries (QSL)"
-filename = "quilted-fabric-api-4.0.0-beta.19+0.64.0-1.19.2.jar"
+filename = "qfapi-4.0.0-beta.24_qsl-3.0.0-beta.24_fapi-0.68.0_mc-1.19.2.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/qvIfYCYJ/versions/zzHaJbi0/quilted-fabric-api-4.0.0-beta.19%2B0.64.0-1.19.2.jar"
+url = "https://cdn.modrinth.com/data/qvIfYCYJ/versions/hmX9pHvE/qfapi-4.0.0-beta.24_qsl-3.0.0-beta.24_fapi-0.68.0_mc-1.19.2.jar"
 hash-format = "sha1"
-hash = "dc88c7b41357c19274d24f1e27a164aa1ff237a0"
+hash = "257bf70e080614f73e745dee12c63cef5f8687de"
 
 [update]
 [update.modrinth]
 mod-id = "qvIfYCYJ"
-version = "zzHaJbi0"
+version = "hmX9pHvE"
 
 [option]
 optional = false

--- a/v1/mods/roughly-enough-items.pw.toml
+++ b/v1/mods/roughly-enough-items.pw.toml
@@ -1,20 +1,19 @@
 name = "Roughly Enough Items (REI)"
-filename = "RoughlyEnoughItems-9.1.565.jar"
+filename = "RoughlyEnoughItems-9.1.580.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/nfn13YXA/versions/COjCjJ9Q/RoughlyEnoughItems-9.1.565.jar"
+url = "https://cdn.modrinth.com/data/nfn13YXA/versions/AzBJJs8X/RoughlyEnoughItems-9.1.580.jar"
 hash-format = "sha1"
-hash = "fd4c2a1c51115f09ff2632d24eb66c06d8f987c3"
+hash = "5af2e66ec5c2be474107c3e9f9972054982f608c"
 
 [update]
 [update.modrinth]
 mod-id = "nfn13YXA"
-version = "COjCjJ9Q"
+version = "AzBJJs8X"
 
 [option]
 optional = true
-default = false
 description = """(Recommended, especially if you haven't played the game in ages)
 
 An item and recipe browser that should save you from having to look up the wiki so much. Also includes items and recipes added by other mods.

--- a/v1/mods/terrablender.pw.toml
+++ b/v1/mods/terrablender.pw.toml
@@ -1,15 +1,15 @@
 name = "TerraBlender (Fabric)"
-filename = "TerraBlender-fabric-1.19.2-2.0.1.129.jar"
+filename = "TerraBlender-fabric-1.19.2-2.0.1.136.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "9f69628f801f5a661c5039b565a492bd6781b83d"
+hash = "5ca6cc1eb69df42650c6d5d478f58e1241109771"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4057291
+file-id = 4205731
 project-id = 565956
 
 [option]

--- a/v1/mods/wthit.pw.toml
+++ b/v1/mods/wthit.pw.toml
@@ -1,16 +1,16 @@
 name = "WTHIT"
-filename = "wthit-quilt-5.13.3.jar"
+filename = "wthit-quilt-5.13.4.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/6AQIaxuO/versions/NW38iTn5/wthit-quilt-5.13.3.jar"
+url = "https://cdn.modrinth.com/data/6AQIaxuO/versions/zHptoLXM/wthit-quilt-5.13.4.jar"
 hash-format = "sha1"
-hash = "0a628b273c8c1151b2429e064967e3bc8523cac0"
+hash = "9c31a7aad960aac1d21b4ae084921cd8704d9b52"
 
 [update]
 [update.modrinth]
 mod-id = "6AQIaxuO"
-version = "NW38iTn5"
+version = "zHptoLXM"
 
 [option]
 optional = true

--- a/v1/mods/xaeros-minimap.pw.toml
+++ b/v1/mods/xaeros-minimap.pw.toml
@@ -1,15 +1,15 @@
 name = "Xaero's Minimap"
-filename = "Xaeros_Minimap_22.16.0_Fabric_1.19.1.jar"
+filename = "Xaeros_Minimap_22.17.0_Fabric_1.19.1.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "df3782ce71f696df6a9daf8d7a85158d29a2755f"
+hash = "e613c45e1373dbddcb1640451237916c34c3abeb"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4026491
+file-id = 4181107
 project-id = 263420
 
 [option]

--- a/v1/mods/xaeros-world-map.pw.toml
+++ b/v1/mods/xaeros-world-map.pw.toml
@@ -1,15 +1,15 @@
 name = "Xaero's World Map"
-filename = "XaerosWorldMap_1.28.1_Fabric_1.19.1.jar"
+filename = "XaerosWorldMap_1.28.7_Fabric_1.19.1.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "45b3e788850cd0c2ae2c5a87e943b41b2f696e4a"
+hash = "efde86a2093103f150d317c5861720734cc56a7d"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 4026544
+file-id = 4193008
 project-id = 317780
 
 [option]

--- a/v1/mods/yacl.pw.toml
+++ b/v1/mods/yacl.pw.toml
@@ -1,16 +1,16 @@
 name = "YetAnotherConfigLib"
-filename = "YetAnotherConfigLib-1.6.0.jar"
+filename = "YetAnotherConfigLib-1.7.1.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/1eAoo2KR/versions/EyhlJvkj/YetAnotherConfigLib-1.6.0.jar"
+url = "https://cdn.modrinth.com/data/1eAoo2KR/versions/mW3CVg5N/YetAnotherConfigLib-1.7.1.jar"
 hash-format = "sha1"
-hash = "82296f5c091f6339f6539c54bde02343789c518a"
+hash = "9694c6e52e946820f9945e2b9ee8a463c1e426fd"
 
 [update]
 [update.modrinth]
 mod-id = "1eAoo2KR"
-version = "EyhlJvkj"
+version = "mW3CVg5N"
 
 [option]
 optional = true

--- a/v1/pack.toml
+++ b/v1/pack.toml
@@ -7,7 +7,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "f3df789bbdb05a2ef11cb8c9448afa49248444f86fa6bde7cbd57f0445a1da2a"
+hash = "f9936b8054140a99999ba040d36916db9b75e7536ac7582e1bdf0f975d58b8d7"
 
 [versions]
 minecraft = "1.19.2"


### PR DESCRIPTION
I ran 'packwiz update --all' and here is the result with two exceptions: it's having a lot of trouble parsing the newest version for Horsebuff so I had to manually set the right version code there. Seems this is a known issue and it's more on mod creators not using machine understandable versioning schemes consistently :( The other was with Oh the Biomes, here's a broken 2.0.0.13 version published that gets selected by the automatic update

Didn't verify that all the other mods are up to date but might spot check a few later on